### PR TITLE
Exclude any OPTIONS request from authentication

### DIFF
--- a/aiohttp_jwt/utils.py
+++ b/aiohttp_jwt/utils.py
@@ -1,8 +1,12 @@
 import asyncio
 import re
 
+from aiohttp.hdrs import METH_OPTIONS
+
 
 def check_request(request, entries):
+    if request.method == METH_OPTIONS:
+        return True
     for pattern in entries:
         if re.match(pattern, request.path):
             return True


### PR DESCRIPTION
this was the original reason for the fork to be created, since we're now managing our fork fully and the original is no longer maintained, let's get this change merged in main (we were using it anyway in our projects via aiohttp-jwt @ git+ssh://git@github.com/tenproduct/aiohttp-jwt@exclude-authentication-in-options)